### PR TITLE
Jm config changes

### DIFF
--- a/var-simplesamlphp/config/authsources.php
+++ b/var-simplesamlphp/config/authsources.php
@@ -10,7 +10,7 @@ $config = array (
         'joebloggs:password' => array(
             'uid' => array('joebloggs'),
             'eduPersonAffiliation' => array('member', 'employee'),
-            'emailAddress' => array('joe@corp.com'),
+            'mail' => array('joe@corp.com'),
         ),
     ),
 );

--- a/var-simplesamlphp/metadata/saml20-idp-hosted.php
+++ b/var-simplesamlphp/metadata/saml20-idp-hosted.php
@@ -19,4 +19,6 @@ $metadata['__DYNAMIC:1__'] = array(
      * user. This must match one of the entries in config/authsources.php.
      */
     'auth' => 'example-userpass',
+
+    'NameIDFormat' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress',
 );

--- a/var-simplesamlphp/metadata/saml20-idp-hosted.php
+++ b/var-simplesamlphp/metadata/saml20-idp-hosted.php
@@ -1,0 +1,22 @@
+<?php
+$metadata['__DYNAMIC:1__'] = array(
+    /*
+     * The hostname for this IdP. This makes it possible to run multiple
+     * IdPs from the same configuration. '__DEFAULT__' means that this one
+     * should be used by default.
+     */
+    'host' => '__DEFAULT__',
+
+    /*
+     * The private key and certificate to use when signing responses.
+     * These are stored in the cert-directory.
+     */
+    'privatekey' => 'server.pem',
+    'certificate' => 'server.crt',
+
+    /*
+     * The authentication source which should be used to authenticate the
+     * user. This must match one of the entries in config/authsources.php.
+     */
+    'auth' => 'example-userpass',
+);

--- a/var-simplesamlphp/metadata/saml20-sp-remote.php
+++ b/var-simplesamlphp/metadata/saml20-sp-remote.php
@@ -39,4 +39,5 @@ $metadata['http://localhost:3000/auth/saml/fl-simplesamlphp-dev/metadata'] = arr
   'NameIDFormat' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress',
   'validate.authnrequest' => false,
   'saml20.sign.assertion' => false,
+  'simplesaml.nameidattribute' => 'mail',
 );

--- a/var-simplesamlphp/metadata/saml20-sp-remote.php
+++ b/var-simplesamlphp/metadata/saml20-sp-remote.php
@@ -40,4 +40,5 @@ $metadata['http://localhost:3000/auth/saml/fl-simplesamlphp-dev/metadata'] = arr
   'validate.authnrequest' => false,
   'saml20.sign.assertion' => false,
   'simplesaml.nameidattribute' => 'mail',
+  'ForceAuthn' => true,
 );

--- a/var-simplesamlphp/metadata/saml20-sp-remote.php
+++ b/var-simplesamlphp/metadata/saml20-sp-remote.php
@@ -32,16 +32,7 @@ $metadata['http://localhost:3000/auth/saml/fl-simplesamlphp-dev/metadata'] = arr
   array (
   ),
   'metadata-set' => 'saml20-sp-remote',
-  'AssertionConsumerService' => 
-  array (
-    0 => 
-    array (
-      'Binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
-      'Location' => 'http://localhost:3000/auth/saml/fl-simplesamlphp-dev',
-      'index' => 0,
-      'isDefault' => true,
-    ),
-  ),
+  'AssertionConsumerService' => 'http://localhost:3000/auth/saml/fl-simplesamlphp-dev',
   'SingleLogoutService' => 
   array (
   ),

--- a/var-simplesamlphp/metadata/saml20-sp-remote.php
+++ b/var-simplesamlphp/metadata/saml20-sp-remote.php
@@ -27,18 +27,8 @@ $metadata['google.com'] = array(
 );
 
 $metadata['http://localhost:3000/auth/saml/fl-simplesamlphp-dev/metadata'] = array (
-  'entityid' => 'http://localhost:3000/auth/saml/fl-simplesamlphp-dev/metadata',
-  'contacts' => 
-  array (
-  ),
-  'metadata-set' => 'saml20-sp-remote',
   'AssertionConsumerService' => 'http://localhost:3000/auth/saml/fl-simplesamlphp-dev',
-  'SingleLogoutService' => 
-  array (
-  ),
   'NameIDFormat' => 'urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress',
-  'validate.authnrequest' => false,
-  'saml20.sign.assertion' => false,
   'simplesaml.nameidattribute' => 'mail',
   'ForceAuthn' => true,
 );


### PR DESCRIPTION
@marcotranchino @urbanautomaton I'd be interested to hear what you think about these changes. I'm specifically interested in:

1. Whether you think we need to keep any of the config stuff I've deleted. I've assumed a lot of the config was copied from the quick start guide and that we might not actually need a lot of it.

2. If there was a reason we didn't initially include the `var-simplesamlphp/metadata/saml20-idp-hosted.php` that was recommended by the quick start guide. I've put it in here, mostly because I wanted to set the `NameIDFormat` option. I'm going to investigate whether I can remove the other stuff in there.

